### PR TITLE
Added 'htpasswd' to path completion list.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -69,7 +69,7 @@ class ScreenlySettings(IterableUserDict):
         except ConfigParser.Error as e:
             logging.debug("Could not parse setting '%s.%s': %s. Using default value: '%s'." % (section, field, unicode(e), default))
             self[field] = default
-        if field in ['database', 'assetdir']:
+        if field in ['database', 'assetdir', 'htpasswd']:
             self[field] = str(path.join(self.home, self[field]))
 
     def _set(self, config, section, field, default):


### PR DESCRIPTION
The htpasswd argument in the configuration file was always treated as an absolute path. It can now also be specified as a path relative to screenly's home directory.
